### PR TITLE
HowTo: Creating and Testing Job DSL job definitions for CatCalZone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.vagrant/

--- a/README.md
+++ b/README.md
@@ -1,8 +1,19 @@
 # CatCalZone Jenkins Job Definitions
 
-These are the Jenkins Jobs for CatCalZone.
+These are the Jenkins job definitions for CatCalZone [Jenkins Job DSL Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Job+DSL+Plugin).
 
-They are defined via the [Jenkins Job DSL Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Job+DSL+Plugin).
-
-Changes on the `master` branch of this repository are applied by the [seed job](https://github.com/jenkinsci/job-dsl-plugin/wiki/Tutorial---Using-the-Jenkins-Job-DSL#1-creating-the-seed-job)
+Changes on the `master` branch of this repository will be [applied by a seed job](https://github.com/jenkinsci/job-dsl-plugin/wiki/Tutorial---Using-the-Jenkins-Job-DSL#1-creating-the-seed-job)
 every 5 minutes.
+
+## Usage
+
+Since everything you push to `master` will be applied to our production Jenkins you typically want to test your changes on a feature branch / in an isolated environment first.
+
+1. create a feature branch, e.g. `git checkout -b feature/add-xyz-job`
+1. spin up a local VM with [our Jenkins server](https://github.com/Zuehlke/cookbooks-jenkins-simple-app): `vagrant up`
+1. go to http://localhost:8080
+1. add a new freestyle job [with a "Process Job DSL" builder](https://github.com/jenkinsci/job-dsl-plugin/wiki/Tutorial---Using-the-Jenkins-Job-DSL)
+1. test your job definition there (see [Job DSL Commands](https://github.com/jenkinsci/job-dsl-plugin/wiki/Job-DSL-Commands))
+1. push your feature branch, e.g. `git push -u origin feature/add-xyz-job`
+1. create a [pull request](https://github.com/CatCalZone/jenkins-jobs/pulls) for easier peer review with your mates
+1. merge the pull request

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Since everything you push to `master` will be applied to our production Jenkins 
 1. spin up a local VM with [our Jenkins server](https://github.com/Zuehlke/cookbooks-jenkins-simple-app): `vagrant up`
 1. go to http://localhost:8080
 1. add a new freestyle job [with a "Process Job DSL" builder](https://github.com/jenkinsci/job-dsl-plugin/wiki/Tutorial---Using-the-Jenkins-Job-DSL)
-1. test your job definition there (see [Job DSL Commands](https://github.com/jenkinsci/job-dsl-plugin/wiki/Job-DSL-Commands))
+1. create and test your job definition there (see [Job DSL Commands](https://github.com/jenkinsci/job-dsl-plugin/wiki/Job-DSL-Commands) and [Job reference](https://github.com/jenkinsci/job-dsl-plugin/wiki/Job-reference))
 1. push your feature branch, e.g. `git push -u origin feature/add-xyz-job`
 1. create a [pull request](https://github.com/CatCalZone/jenkins-jobs/pulls) for easier peer review with your mates
 1. merge the pull request

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,15 @@
+Vagrant.configure(2) do |config|
+
+  config.vm.box = "chef/ubuntu-14.04"
+  config.omnibus.chef_version = "12.3.0"
+
+  config.vm.define :jenkins do |jenkins|
+    jenkins.vm.network :forwarded_port, guest: 8080, host: 8080
+
+    jenkins.toplevel_cookbook.url = "https://github.com/Zuehlke/cookbooks-jenkins-simple-app"
+    jenkins.vm.provision :chef_solo do |chef|
+      chef.add_recipe "jenkins-simple-app::default"
+    end
+  end
+
+end


### PR DESCRIPTION
This PR adds a `Vagrantfile` to spin up our CatCalZone jenkins server in a local Vagrant VM which can be used for testing new Job DSL definitions.

It also adds a Usage section to the README which explains the intended usage.

/cc @damphyr @MaltePir @aderenbach (+ David Vogt)
